### PR TITLE
Correctly use and save centering calibrations #20

### DIFF
--- a/lib/config.py
+++ b/lib/config.py
@@ -108,8 +108,8 @@ class Config:
         Creates a YAML configuration file based on the values of the `params`
         dictionary.
         """
-        with open(self.config_file) as infile:
-            self.params = yaml.load(infile)
+        with open(self.config_file, 'w') as outfile:
+            yaml.dump(self.params, outfile)
 
     def get(self, *kvs):
         """

--- a/lib/tables.py
+++ b/lib/tables.py
@@ -14,7 +14,7 @@ def _print(message):
         print(message)
 
 
-def setup(server, name='vision', printtoo=True):
+def setup(server, name='vision', printtoo=False):
     """
     Configures and connects to a NetworkTables service running
     on the server given (typically an IP address).
@@ -75,7 +75,8 @@ def send_fudge(key, value):
     try:
         if __table:
             fudges = __table.getSubTable("fudges")
-            return fudges.putValue(key, value)
+            _print("  - fudges.{0}: {1}".format(key, value))
+            return fudges.putNumber(key, value)
         else:
             msg = "Not connected to NetworkTables server. Run setup() first."
             raise Exception(msg)
@@ -83,14 +84,14 @@ def send_fudge(key, value):
         print("ERROR: {0}".format(e))
 
 
-def get_fudge(key, value):
+def get_fudge(key, defaultValue=None):
     """
     Gets a value from the fudge subtable in NetworkTables.
     """
     try:
         if __table:
             fudges = __table.getSubTable("fudges")
-            return fudges.getValue(key)
+            return fudges.getNumber(key, defaultValue)
         else:
             msg = "Not connected to NetworkTables server. Run setup() first."
             raise Exception(msg)

--- a/robot_vision.py
+++ b/robot_vision.py
@@ -5,45 +5,94 @@ Use `java -jar support/OutlineViewer-1.0.1.jar` in terminal to create a local
 server, once you have everything installed (see README)
 """
 from lib import config, tables, target_tracker, color_mask, util
+from time import sleep
 import argparse
 
+# The `debug` global variable is a number that corresponds to how much
+# debugging information we should attempt to print:
+#   0 :: No output except for errors
+#   1 :: Output only changes that may be of interest
+#   2 :: Output all data sent to NetworkTables
+
+debug = 1
+
+# The `fudges` is a dictionary of offsets we use to help calibrate the
+# target analysis based on the position of the camera and the _goal_ of
+# the robot:
+
+fudges = {"center_x": 0,
+          "center_y": 0
+          }
+
+
+def debug_message(level, *msg):
+    """
+    A wee helper function for printing debugging messages if (and
+    only if), the global variable, debug has been set...which should
+    come from the configuration file.
+    """
+    global debug
+    if debug >= level:
+        print(*msg)
+
+
 def run(cfg):
+    """
+    The primary code interface for the Vision Analysis program and the
+    RoboRIO hosted NetworkTables.
+
+    The configuration object, cfg, should have all the goodies on what
+    to connect to, including the vision camera, the server hosting the
+    NetworkTables, and the color range values.
+    """
     # cfg is the list of values that contain channel, server, lower, and upper
-    channel = cfg.get('channel')
-    server = cfg.get('networktables')
+    global debug
+    debug = cfg.get_default("debug", 1)
+
+    global fudges
+    fudges = cfg.get_default("fudges", fudges)
+
+    channel = cfg.get_default('channel', 0)
+    server = cfg.get_default('networktables', '10.27.33.2')
     lu = cfg.get("color", "yellow")
-
-    fudges = cfg.get_default("fudges", {"center_x": 0,
-                                        "center_y": 0
-                                        })
-
     lower, upper = color_mask.unpack_range(lu)
 
     camera, width, height = util.get_video(channel)
+    debug_message(1, "camera:", camera)
 
-    debug = cfg.get_default("debug", False)
-    tables.setup(server, printtoo = debug)
+    if debug >= 2:
+        tables.setup(server, printtoo=True)
+    else:
+        tables.setup(server)
+
+    # We need to wait a bit for both the camera and the NetworkTables server
+    # to "come online", so let's add a wee kludge and wait 5 seconds:
+    sleep(5)
+
+    # Send our fudgys and then put them into the NetworkTables, so that
+    # we could change them if we want to.
+    tables.send_fudge("center_x", fudges['center_x'])
+    tables.send_fudge("center_y", fudges['center_y'])
 
     while True:
-        if debug:
-            print("camera:", camera)
         hsv, _ = util.get_hsv(camera)
-        if debug:
-            print("hsv:", hsv)
         masked_img = color_mask.get_mask(hsv, lower, upper)
         target = target_tracker.single_target(masked_img)
-        if debug:
-            print("target:", target)
-        send_target_data(target, fudges)
+
+        send_target_data(target)
         update_fudges(tables, cfg)
 
 
-def send_target_data(target, fudges):
+def send_target_data(target):
+    """
+    Send the target information over to the NetworkTables (using the `tables`
+    interface) including any fudge factor offsets.
+    """
     if target is not None:
         tables.send('center_x', target["center"]["x"] + fudges["center_x"])
         tables.send('center_y', target["center"]["y"] + fudges["center_y"])
         # tables.send('distance', target.distance)
-        tables.send('orientation',target["orientation"])
+        tables.send('orientation', target["orientation"])
         tables.send('size', target["size"])
         tables.send('height', target["height"])
         tables.send('width', target["width"])
@@ -63,18 +112,33 @@ def send_target_data(target, fudges):
         tables.send("ydir", "")
         tables.send("ymag", 0)
 
+
 def update_fudges(tables, cfg):
     """
-    Compare the values that ma
+    Compare the values from the NetworkTables server (which we may change
+    during calibration), and if they are different, persist them in our
+    configuration file.
     """
+    global fudges
+
     x = tables.get_fudge("center_x")
     y = tables.get_fudge("center_y")
-    if x != cfg.get("fudges", "center_x"):
+
+    # If the fudge factor isn't in the NetworkTables, we will get a None value,
+    # and should be ignored. However, if we get a value that is different than
+    # what we have stored, let's update our fudgy values in our config:
+    if x and x != fudges['center_x']:
+        debug_message(1, "Changing `center_x` to ", x)
+        fudges['center_x'] = x
         cfg.set("fudges", "center_x", x)
         cfg.save()
-    if y != cfg.get("fudges", "center_y"):
+
+    if y and y != fudges['center_y']:
+        debug_message(1, "Changing `center_y` to ", y)
+        fudges['center_y'] = y
         cfg.set("fudges", "center_y", y)
         cfg.save()
+
 
 if __name__ == '__main__':
     # Able to add through the command line what config file to use, but the
@@ -83,5 +147,7 @@ if __name__ == '__main__':
     parser.add_argument('-c', '--config', help="Configuration filename")
     args = parser.parse_args()
 
-    cfg = config.Config(args.config)  # from config file make an instance of the Config class
+    # from config file make an instance of the Config class
+    cfg = config.Config(args.config)
+
     run(cfg)


### PR DESCRIPTION
(*Note:* I am breaking protocol with this commit, as it seems the team is busy
with schoolwork, and we really could use these changes now...feel free to cry
foul and re-implement these changes and make a better pull request...  ;-)

Read center-goal calibration values (fudge factors) from the configuration file
and amends those to the target tracking values.

If either the `x` or `y` calibration values are changed on the `fudges` subtable
in NetworkTables server, they change the values and also saves those values in
the configuration file.

This also addresses a few bugs encountered during testing (I really should
insist you write unit tests for all of these functions):

  * The config.save now save configuration changes
  * The NetworkTables now defaults to not printing all sent values
  * The tables.get_fudge now has None for a default value